### PR TITLE
Sidekiq 8

### DIFF
--- a/lib/sidekiq-scheduler/version.rb
+++ b/lib/sidekiq-scheduler/version.rb
@@ -1,3 +1,3 @@
 module SidekiqScheduler
-  VERSION = "5.0.6"
+  VERSION = "5.0.7"
 end

--- a/sidekiq-scheduler.gemspec
+++ b/sidekiq-scheduler.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.metadata = { 'rubygems_mfa_required' => 'true' }
 
-  s.add_dependency 'sidekiq', '>= 6', '<= 8'
+  s.add_dependency 'sidekiq', '>= 6', '< 9'
   s.add_dependency 'rufus-scheduler', '~> 3.2'
 
   s.add_development_dependency 'rake', '~> 12.0'

--- a/sidekiq-scheduler.gemspec
+++ b/sidekiq-scheduler.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.metadata = { 'rubygems_mfa_required' => 'true' }
 
-  s.add_dependency 'sidekiq', '>= 6', '< 8'
+  s.add_dependency 'sidekiq', '>= 6', '<= 8'
   s.add_dependency 'rufus-scheduler', '~> 3.2'
 
   s.add_development_dependency 'rake', '~> 12.0'


### PR DESCRIPTION
We are blocked from upgrading to version 8 of the `sidekiq` gem by this gem. In order to make this gem compatible, I updated the `sidekiq` dependency in `sidekiq-scheduler.gemspec` to `'>= 6', '< 9'`

I will submit a PR from this forked version back to the original repo. We can use this version while we wait for their approval.